### PR TITLE
Added new property VisibilityForDesign to make control visible for desig...

### DIFF
--- a/RateMyApp/Controls/FeedbackOverlay.xaml
+++ b/RateMyApp/Controls/FeedbackOverlay.xaml
@@ -18,7 +18,7 @@
     FontFamily="{StaticResource PhoneFontFamilyNormal}"
     FontSize="{StaticResource PhoneFontSizeNormal}"
     Foreground="{StaticResource PhoneForegroundBrush}"
-    Visibility="Collapsed"
+    Visibility="{Binding VisibilityForDesign, RelativeSource={RelativeSource Self}}"
     d:DesignHeight="480" d:DesignWidth="480">
 
     <UserControl.Resources>
@@ -45,16 +45,16 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-                
+
                 <TextBlock x:Name="title" Grid.ColumnSpan="2" Margin="12,0,12,0" HorizontalAlignment="Left" 
                            Style="{StaticResource PhoneTextTitle2Style}" FontWeight="Bold" TextWrapping="Wrap" />
-                
+
                 <TextBlock x:Name="message" Grid.ColumnSpan="2" Grid.Row="1" Margin="12,12,12,12" HorizontalAlignment="Left" 
                            Style="{StaticResource PhoneTextNormalStyle}" TextWrapping="Wrap" />
 
                 <Button x:Name="yesButton" Margin="0,0,0,0" Grid.Row="2" />
                 <Button x:Name="noButton" Margin="0,0,0,0" Grid.Row="2" Grid.Column="1" />
-                
+
             </Grid>
             <Border.Projection>
                 <PlaneProjection x:Name="xProjection" />

--- a/RateMyApp/Controls/FeedbackOverlay.xaml.cs
+++ b/RateMyApp/Controls/FeedbackOverlay.xaml.cs
@@ -32,6 +32,19 @@ namespace RateMyApp.Controls
     /// </summary>
     public partial class FeedbackOverlay : UserControl
     {
+        public static readonly DependencyProperty VisibilityForDesignProperty =
+            DependencyProperty.Register("VisibilityForDesign", typeof(System.Windows.Visibility), typeof(FeedbackOverlay), new PropertyMetadata(System.Windows.Visibility.Collapsed, null));
+
+        public static void SetVisibilityForDesign(FeedbackOverlay element, System.Windows.Visibility value)
+        {
+            element.SetValue(VisibilityForDesignProperty, value);
+        }
+
+        public static System.Windows.Visibility GetVisibilityForDesign(FeedbackOverlay element)
+        {
+            return (System.Windows.Visibility)element.GetValue(VisibilityForDesignProperty);
+        }
+
         // Use this from XAML to control whether animation is on or off
         #region EnableAnimation Dependency Property
 


### PR DESCRIPTION
...ning and developing.

I had a problem, where the control wasn't properly displayed in my app. It was quite hard to find the design problem. Therefore I added a property called VisibilityForDesign that allows developers to make the control visible in the designers (vs, blend).

My first attempt was to "override" the visiblity property, but that didn't work to I introduced a new Property, which binds to the Visibility Property of the UserControl it self. Default value is "collapsed". That way no changes in existing code needed.

In order to make the control visible, set VisibilityForDesign="Visible".
